### PR TITLE
Improvements to codec attachment stuff

### DIFF
--- a/src/main/java/net/neoforged/neoforge/attachment/DataAttachmentOps.java
+++ b/src/main/java/net/neoforged/neoforge/attachment/DataAttachmentOps.java
@@ -9,26 +9,19 @@ import com.mojang.serialization.DataResult;
 import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.HolderLookup;
-import net.minecraft.resources.DelegatingOps;
 import net.minecraft.resources.RegistryOps;
 import net.minecraft.util.ExtraCodecs;
 
-public class DataAttachmentOps<T, TOwner> extends DelegatingOps<T> {
-    private final HolderLookup.Provider holderLookup;
+public class DataAttachmentOps<T, TOwner> extends RegistryOps<T> {
     private final TOwner parent;
 
-    protected DataAttachmentOps(RegistryOps<T> regOps, HolderLookup.Provider holderLookup, TOwner parent) {
+    protected DataAttachmentOps(RegistryOps<T> regOps, TOwner parent) {
         super(regOps);
-        this.holderLookup = holderLookup;
         this.parent = parent;
     }
 
     public static <T, TOwner extends IAttachmentHolder> DataAttachmentOps<T, TOwner> create(HolderLookup.Provider holderLookup, DynamicOps<T> targetOps, TOwner parent) {
-        return new DataAttachmentOps<>(holderLookup.createSerializationContext(targetOps), holderLookup, parent);
-    }
-
-    public HolderLookup.Provider registryLookup() {
-        return holderLookup;
+        return new DataAttachmentOps<>(holderLookup.createSerializationContext(targetOps), parent);
     }
 
     public static <O, TOwner extends IAttachmentHolder> RecordCodecBuilder<O, TOwner> holder(Class<TOwner> holder) {

--- a/src/main/java/net/neoforged/neoforge/codec/NBTSerializableCodec.java
+++ b/src/main/java/net/neoforged/neoforge/codec/NBTSerializableCodec.java
@@ -11,8 +11,7 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.DynamicOps;
-import java.lang.reflect.ParameterizedType;
-import java.util.Arrays;
+
 import java.util.function.Supplier;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.RegistryOps;
@@ -22,29 +21,10 @@ import net.neoforged.neoforge.common.util.INBTSerializable;
  * A codec for instances of {@link INBTSerializable}.
  *
  * @param defaultSupplier Used to construct empty instances.
- * @param serializerClass The class implementing {@link INBTSerializable}.
- * @param nbtTypeClass    The type of NBT tag the serializer serializes into.
  * @param <S>             Serializer type param.
  * @param <NBT>           NBT type param.
  */
-public record NBTSerializableCodec<S extends INBTSerializable<NBT>, NBT extends Tag>(Supplier<S> defaultSupplier,
-        Class<S> serializerClass,
-        Class<NBT> nbtTypeClass) implements Codec<S> {
-    public static <S extends INBTSerializable<NBT>, NBT extends Tag> Codec<S> forSerializable(Class<S> serializerClass, Supplier<S> defaultSupplier) {
-        final var nbtTypeClass = Arrays.stream(serializerClass.getGenericInterfaces())
-                .filter(ParameterizedType.class::isInstance)
-                .map(ParameterizedType.class::cast)
-                .filter(pt -> INBTSerializable.class == pt.getRawType())
-                .map(pt -> pt.getActualTypeArguments()[0])
-                .findFirst()
-                .orElseThrow();
-
-        if (nbtTypeClass instanceof Class<?> nbt2) {
-            return new NBTSerializableCodec<>(defaultSupplier, serializerClass, (Class<NBT>) nbt2);
-        }
-
-        throw new RuntimeException("The type of NBT serializable could not be determined! Do you implement it more than once?");
-    }
+public record NBTSerializableCodec<S extends INBTSerializable<NBT>, NBT extends Tag>(Supplier<S> defaultSupplier) implements Codec<S> {
 
     @Override
     public <T> DataResult<Pair<S, T>> decode(DynamicOps<T> ops, T input) {
@@ -59,25 +39,27 @@ public record NBTSerializableCodec<S extends INBTSerializable<NBT>, NBT extends 
     }
 
     private <T> DataResult<Pair<S, T>> decodeNBT(T input, RegistryOps.HolderLookupAdapter adapter, Tag asNBT) {
-        if (nbtTypeClass.isInstance(asNBT)) {
-            S instance = defaultSupplier.get();
-            try {
-                instance.deserializeNBT(adapter.lookupProvider, nbtTypeClass.cast(asNBT));
-                return DataResult.success(Pair.of(instance, input));
-            } catch (Exception ex) {
-                return DataResult.error(() -> "Error finalizing deserialization. Did not deserialize to the expected class.",
-                        Pair.of(null, input));
-            }
-        } else {
-            return DataResult.error(() -> "Not the proper NBT type.", Pair.of(null, input));
+        S instance = defaultSupplier.get();
+        try {
+            //noinspection unchecked
+            instance.deserializeNBT(adapter.lookupProvider, (NBT) asNBT);
+            // Any type issue from the above line will be caught and logged
+            return DataResult.success(Pair.of(instance, input));
+        } catch (Exception ex) {
+            return DataResult.error(() -> "Error deserializing: " + ex + ".",
+                    Pair.of(null, input));
         }
     }
 
     @Override
     public <T> DataResult<T> encode(S input, DynamicOps<T> ops, T prefix) {
         if (ops instanceof RegistryOps<T> regOps && regOps.lookupProvider instanceof RegistryOps.HolderLookupAdapter adapter) {
-            var serialized = input.serializeNBT(adapter.lookupProvider);
-            return TAG_CODEC.encode(nbtTypeClass.cast(serialized), ops, prefix);
+            try {
+                var serialized = input.serializeNBT(adapter.lookupProvider);
+                return TAG_CODEC.encode(serialized, ops, prefix);
+            } catch (Exception ex) {
+                return DataResult.error(() -> "Error serializing: " + ex + ".");
+            }
         }
 
         return DataResult.error(() -> "Was not passed registry ops for serialization; cannot continue.");

--- a/src/main/java/net/neoforged/neoforge/common/util/INBTSerializable.java
+++ b/src/main/java/net/neoforged/neoforge/common/util/INBTSerializable.java
@@ -23,14 +23,13 @@ public interface INBTSerializable<T extends Tag> {
     /**
      * Creates a codec for an implementation of {@link INBTSerializable}.
      *
-     * @param serializableClass The class implementing INBTSerializable.
      * @param defaultSupplier   A default supplier for the class; typically a method reference.
      * @param <S>               Type of class implementing INBTSerializable.
      * @param <NBT>             Type of NBT tag the class serializes to.
      * @return A codec for the serializable class.
      */
-    static <S extends INBTSerializable<NBT>, NBT extends Tag> Codec<S> codec(Class<S> serializableClass, Supplier<S> defaultSupplier) {
-        return NBTSerializableCodec.forSerializable(serializableClass, defaultSupplier);
+    static <S extends INBTSerializable<NBT>, NBT extends Tag> Codec<S> codec(Supplier<S> defaultSupplier) {
+        return new NBTSerializableCodec<>(defaultSupplier);
     }
 
     static <T extends Tag, S extends INBTSerializable<T>> StreamCodec<RegistryFriendlyByteBuf, S> streamCodec(Supplier<S> defaultSupplier) {

--- a/tests/src/junit/java/net/neoforged/neoforge/unittest/codec/NBTSerializableCodecTests.java
+++ b/tests/src/junit/java/net/neoforged/neoforge/unittest/codec/NBTSerializableCodecTests.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(EphemeralTestServerProvider.class)
 public class NBTSerializableCodecTests {
-    private static final Codec<ItemStackHandler> ISH_CODEC = INBTSerializable.codec(ItemStackHandler.class, ItemStackHandler::new);
+    private static final Codec<ItemStackHandler> ISH_CODEC = INBTSerializable.codec(ItemStackHandler::new);
     private static final StreamCodec<RegistryFriendlyByteBuf, ItemStackHandler> ISH_STREAM_CODEC = INBTSerializable.streamCodec(ItemStackHandler::new);
 
     private static ItemStackHandler makeItemHandler() {


### PR DESCRIPTION
Here's my take at cleaning up some of the remaining bits of wackiness in that PR -- notably, fixing `DataAttachmentOps` to be `RegistryOps` (which turned out to be really easy), and removing the last of the unnecessary `Class<?>` stuff from `NBTSerializableCodec`.